### PR TITLE
refactor: improve readability & check for errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 PREFIX ?= /usr
+LD_LIBS = -lprocps
 
 install:
-	@gcc tuxfetch.c -o $(DESTDIR)$(PREFIX)/bin/tuxfetch
+	@gcc tuxfetch.c -o $(DESTDIR)$(PREFIX)/bin/tuxfetch $(LD_LIBS)
 
 uninstall:
 	@rm $(DESTDIR)$(PREFIX)/bin/tuxfetch


### PR DESCRIPTION
* now if a function fails, the error is reported to stderr and the
  program exists with `EXIT_FAILURE`
* now `get_ram_usage` actually returns the ram usage (note that
  ram_total - ram_free != ram_usage) using libprocps
* use utsname.release to get the kernel release version
* use pw->pw_shell to get the user shell
* and mostly readability improvements